### PR TITLE
Docs fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![badge-ga](https://github.com/firedrakeproject/mpi-pytest/actions/workflows/ci_pipeline.yml/badge.svg?branch=master)](https://github.com/firedrakeproject/mpi-pytest/actions/workflows/ci_pipeline.yml)
-
 # mpi-pytest
 
 Pytest plugin that lets you run tests in parallel with MPI.
@@ -53,7 +51,7 @@ to each test to allow one to select all tests with a particular number of proces
 For example, to select all parallel tests on 3 processors, one should run:
 
 ```bash
-$ mpiexec -n 3 pytest -m parallel[3]
+$ mpiexec -n 3 pytest -m "parallel[3]"
 ```
 
 Serial tests - those either unmarked or marked `@pytest.mark.parallel(1)` - can

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ with `mpiexec`, no additional configuration is necessary. For example, to run
 all of the parallel tests on 2 ranks one needs to execute:
 
 ```bash
-$ mpiexec -n 2 pytest -m parallel[2]
+$ mpiexec -n 2 pytest -m "parallel[2]"
 ```
 
 ## `parallel_assert`


### PR DESCRIPTION
Some shells require quotes when defining the number of parallel tasks to limit testing to, i.e. you need to run `mpiexec -n 3 pytest -m "parallel[3]"` instead of `mpiexec -n 3 pytest -m parallel[3]`. This PR changes the README to show the more general version with quotes.

Also, turns out the CI badge was not working. Since I don't have the rights to add one that works, I just removed the current badge.