### PR TITLE
CI pipeline for OpenMPI

### DIFF
--- a/.github/etc/test_environment_openmpi.yml
+++ b/.github/etc/test_environment_openmpi.yml
@@ -1,0 +1,9 @@
+---
+
+name: OpenMPI_test_env
+channels:
+  - conda-forge
+dependencies:
+  - pytest
+  - openmpi
+  - mpi4py

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -9,13 +9,13 @@ on:
     - cron: '1 5 * * 1'
 
 jobs:
-
   tests:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        mpi: ['mpich', 'openmpi']
     defaults:
       run:
         shell: bash -l {0}
@@ -25,12 +25,20 @@ jobs:
       - name: Install Conda environment with Micromamba
         uses: mamba-org/setup-micromamba@v1
         with:
-          environment-file: ".github/etc/test_environment_mpich.yml"
+          environment-file: ".github/etc/test_environment_${{ matrix.mpi }}.yml"
           create-args: >-
               python=${{ matrix.python }}
       - name: Install mpi-pytest as a package in the current environment
         run: |
           pip install --no-deps -e .
       - name: Run tests
+        if: matrix.mpi == 'mpich'
         run: |
           pytest --continue-on-collection-errors -v tests
+      - name: Run tests
+        if: matrix.mpi == 'openmpi'
+        run: |
+          for n in $(seq 1 3);
+          do
+              mpiexec -np n pytest --continue-on-collection-errors -v -m "parallel[${n}]" tests
+          done

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -40,5 +40,5 @@ jobs:
         run: |
           for n in $(seq 1 3);
           do
-              mpiexec -np ${n} pytest --continue-on-collection-errors -v -m "parallel[${n}]" tests
+              mpiexec --oversubscribe -np ${n} pytest --continue-on-collection-errors -v -m "parallel[${n}]" tests
           done

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -40,5 +40,5 @@ jobs:
         run: |
           for n in $(seq 1 3);
           do
-              mpiexec -np n pytest --continue-on-collection-errors -v -m "parallel[${n}]" tests
+              mpiexec -np ${n} pytest --continue-on-collection-errors -v -m "parallel[${n}]" tests
           done


### PR DESCRIPTION
I would be interested if this module worked more seamlessly with OpenMPI and seems I am not alone. I added a testing pipeline that runs the tests with OpenMPI, using commands such as `mpiexec -np 3 pytest -m "parallel[3]"`. Hope this is useful. 