### PR TITLE
Always mark unmarked tests as 'parallel[1]'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,6 @@ jobs:
           : # 'forking' mode
           pytest -v tests
           : # 'non-forking' mode
-          ${{ matrix.mpiexec }} -n 1 pytest -v -m "not parallel or parallel[1]" tests
+          ${{ matrix.mpiexec }} -n 1 pytest -v -m parallel[1] tests
           ${{ matrix.mpiexec }} -n 2 pytest -v -m parallel[2] tests
           ${{ matrix.mpiexec }} -n 3 pytest -v -m parallel[3] tests

--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ to each test to allow one to select all tests with a particular number of proces
 For example, to select all parallel tests on 3 processors, one should run:
 
 ```bash
-$ mpiexec -n 3 pytest -m "parallel[3]"
+$ mpiexec -n 3 pytest -m parallel[3]
 ```
 
 Serial tests - those either unmarked or marked `@pytest.mark.parallel(1)` - can
 be selected by running:
 
 ```bash
-$ pytest -m "not parallel or parallel[1]"
+$ pytest -m parallel[1]
 ```
 
 ### Forking mode
@@ -84,10 +84,6 @@ This is convenient for development for a number of reasons:
 
 There are however a number of downsides:
 
-* Only one mainstream MPI distribution ([MPICH](https://www.mpich.org/)) supports
-  nested calls to `MPI_Init`. If your 'parent' `pytest` process initialises MPI
-  (for instance by executing `from mpi4py import MPI`) then this will cause non-MPICH
-  MPI distributions to crash.
 * Forking a subprocess can be expensive since a completely fresh Python interpreter
   is launched each time.
 * Sandboxing each test means that polluted global state at the end of a test cannot
@@ -101,7 +97,7 @@ with `mpiexec`, no additional configuration is necessary. For example, to run
 all of the parallel tests on 2 ranks one needs to execute:
 
 ```bash
-$ mpiexec -n 2 pytest -m "parallel[2]"
+$ mpiexec -n 2 pytest -m parallel[2]
 ```
 
 ## `parallel_assert`

--- a/pytest_mpi/plugin.py
+++ b/pytest_mpi/plugin.py
@@ -93,10 +93,6 @@ def pytest_collection_modifyitems(config, items):
 
     _plugin_in_use = any(item.get_closest_marker("parallel") for item in items)
 
-    # if mpi-pytest is not being used then don't mark anything
-    if not _plugin_in_use:
-        return
-
     for item in items:
         if item.get_closest_marker("parallel"):
             nprocs = _extract_nprocs_for_single_test(item)


### PR DESCRIPTION
This means we can avoid the clunky

    -m "not parallel or parallel[1]"

I have tested this locally but I don't know that there is a satisfactory way to test this on CI.