### PR TITLE
Mpi4py detection

### DIFF
--- a/pytest_mpi/plugin.py
+++ b/pytest_mpi/plugin.py
@@ -315,7 +315,9 @@ def detect_mpi_implementation() -> MPIImplementation:
             "where you can specify a different MPI executable"
         )
 
-    if any(
+    if "mpich" in version:
+        return MPIImplementation.MPICH
+    elif any(
         version_str in version
         for version_str in [
             "open mpi",
@@ -327,8 +329,6 @@ def detect_mpi_implementation() -> MPIImplementation:
         ]
     ):
         return MPIImplementation.OPENMPI
-    elif "mpich" in version:
-        return MPIImplementation.MPICH
     elif "microsoft" in version:
         return MPIImplementation.MSMPI
     else:


### PR DESCRIPTION
Uses `mpi4py` to perform MPI implementation in forking mode. This does not require MPI initialization or finalization.
I have also taken the liberty of adding a few extra version string comparisons to find the backend implementation just in case there is some other weird open mpi name that pops up.

Unfortunately, mpi4py only returns a string and then it is required to be checked for the version type. 
I have noticed that mpich, openmpi, and microsoft mpi all _like_ to have their name as the first thing in the returned string, so it could be possible to use `version.startswith("open")` instead of the `in` statement that is currently implemented. However that is not necessarily a guarantee and if the format changes this version should hopefully still function.

I took the 


fixes #27, fixes #28 